### PR TITLE
Check partial references

### DIFF
--- a/src/declarations/parser.ts
+++ b/src/declarations/parser.ts
@@ -11,6 +11,12 @@ function joinId(prefix: string, name: string): string {
  * isn't subtle enough to deal with it (at least for now)
  */
 export class Parser extends Graph.DirectedAcyclicGraph<ParserNode> {
+  protected _templates: string[] = []
+
+  get templates(): readonly string[] {
+    return Object.freeze([...this._templates])
+  }
+
   protected ensureChild<T extends ParserNode>(
     parentNode: ParserNode,
     node: T,
@@ -133,5 +139,7 @@ export class Parser extends Graph.DirectedAcyclicGraph<ParserNode> {
     }
 
     this.mergeSpans(root, spans)
+
+    this._templates.push(templateName)
   }
 }

--- a/src/declarations/renderer.ts
+++ b/src/declarations/renderer.ts
@@ -184,10 +184,22 @@ export class Renderer {
   toString(): string {
     const templateMap: Record<string, string> = {}
 
+    const templatesVisited = new Set<string>()
+
     for (const n of this.parsed.nodes()) {
       if (n.type === 'TEMPLATE') {
         this.resolveTemplate(n)
         templateMap[n.id] = this.resolutions.get(n.id)!.typeName
+        templatesVisited.add(n.id)
+      }
+    }
+
+    // Sanity check: ensure that any partials referenced were actually supplied
+    // to the parser and rendered
+    const parsedTemplates = this.parsed.templates
+    for (const t of templatesVisited) {
+      if (!parsedTemplates.includes(t)) {
+        throw new Error(`Unknown template: ${t}`)
       }
     }
 

--- a/src/declarations/renderer_spec.ts
+++ b/src/declarations/renderer_spec.ts
@@ -135,6 +135,12 @@ describe('Parser', function () {
         person: [{ type: 'RECORD', typeName: 'TemplatePerson' }],
       })
     })
+
+    it('throws before generating type with broken reference', function () {
+      const template = '{{> missing_partial}}'
+      const w = TestWriter.resolve({ template })
+      expect(() => w.toString()).toThrow()
+    })
   })
 
   describe('full tests', function () {


### PR DESCRIPTION
If a template references `{{>my_partial}}` but `my_partial.mustache` is
never supplied to the parser, attempting to render the template's types
will now throw an error.
